### PR TITLE
Support callback function in replaceMessages

### DIFF
--- a/src/hooks/internal/useMessagesInternal.ts
+++ b/src/hooks/internal/useMessagesInternal.ts
@@ -401,12 +401,18 @@ export const useMessagesInternal = () => {
 	/**
 	 * Replaces (overwrites entirely) the current messages with the new messages.
 	 * 
-	 * @param newMessages new messages to set/replace
+	 * @param newMessagesOrUpdater new messages array or a function that receives current messages
+	 * and returns new messages
 	 */
-	const replaceMessages = useCallback((newMessages: Array<Message>) => {
+	const replaceMessages = useCallback((
+		newMessagesOrUpdater: Array<Message> | ((currentMessages: Array<Message>) => Array<Message>)
+	) => {
+		const newMessages = typeof newMessagesOrUpdater === 'function' 
+			? newMessagesOrUpdater(syncedMessagesRef.current) 
+			: newMessagesOrUpdater;
 		setSyncedMessages(newMessages);
 		handlePostMessagesUpdate(newMessages);
-	}, [handlePostMessagesUpdate])
+	}, [handlePostMessagesUpdate, syncedMessagesRef])
 
 	return {
 		simulateStreamMessage,


### PR DESCRIPTION
#### Description

This PR adds support for a callback pattern in the replaceMessages function, similar to React's setState. This allows users to update messages based on the current state without causing infinite re-render loops when used inside useEffect.

Closes #329

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

The replaceMessages function now accepts either:
  1. An array of messages (existing behavior - maintains backward compatibility)
  2. A callback function that receives the current messages and returns new messages

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [no] Relevant comments/docs have been added/updated (for bug fixes/features)
  - The docs don't seem to be in this repo? 👀 