### PR TITLE
Fix: prevent ignoring return value in speech synthesis voice selection

### DIFF
--- a/src/services/AudioService.ts
+++ b/src/services/AudioService.ts
@@ -23,15 +23,11 @@ export const speak = (message: string, language: string, voiceNames: string[], r
 
 	let voiceIdentified = false;
 	for (const voiceName of voiceNames) {
-		window.speechSynthesis.getVoices().find((voice) => {
-			if (voice.name === voiceName) {
-				utterance.voice = voice;
-				window.speechSynthesis.speak(utterance);
-				voiceIdentified = true;
-				return;
-			}
-		});
-		if (voiceIdentified) {
+		const matchedVoice = window.speechSynthesis.getVoices().find((voice) => voice.name === voiceName);
+		if(matchedVoice){
+			utterance.voice = matchedVoice;
+			window.speechSynthesis.speak(utterance);
+			voiceIdentified = true;
 			break;
 		}
 	}


### PR DESCRIPTION
### Description

#### Summary
This PR fixes a SonarQube issue (TypeScript:S2201 – "Return values should not be ignored") 
in the speech synthesis voice selection logic.

### What change does this PR introduce?

#### Changes
- Replaced the use of `Array.find` with proper handling of its return value
- Ensured the matched voice is assigned to the utterance before calling `speak`
- Improved code readability and compliance with static analysis rules

#### Why
SonarQube detected that the return value of `find` was being ignored, which could 
lead to confusion or potential bugs. This fix ensures the return value is properly 
utilized and eliminates the warning.

#### Testing
- Verified that voices are still correctly matched by name
- Confirmed that speech synthesis works as expected after the change

Please select the relevant option(s).

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

### What is the proposed approach?

The current implementation uses Array.find only for its side effects, without using the returned value, which triggers TypeScript:S2201.

#### To resolve this:
- Capture the return value from find and assign it to the utterance if it exists, or
- Replace find with some, which is more semantically correct when only checking for existence and performing side effects.

#### This ensures that:
- No return values are ignored.
- The code is cleaner and compliant with SonarQube rules.
- Functionality remains unchanged — the correct voice is still selected and spoken.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [x] Relevant comments/docs have been added/updated (for bug fixes/features)