### PR TITLE
Added tests for useButtonInternal

### DIFF
--- a/__tests__/hooks/internal/useButtonsInternal.test.ts
+++ b/__tests__/hooks/internal/useButtonsInternal.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from "@testing-library/react";
+import { useButtonInternal } from "../../../src/hooks/internal/useButtonsInternal";
+
+// Mock dependencies
+jest.mock("../../../src/context/SettingsContext", () => ({
+	useSettingsContext: jest.fn(),
+}));
+jest.mock("../../../src/utils/buttonBuilder", () => ({
+	createAudioButton: jest.fn(() => "AudioButton"),
+	createCloseChatButton: jest.fn(() => "CloseChatButton"),
+	createEmojiButton: jest.fn(() => "EmojiButton"),
+	createFileAttachmentButton: jest.fn(() => "FileAttachmentButton"),
+	createNotificationButton: jest.fn(() => "NotificationButton"),
+	createSendButton: jest.fn(() => "SendButton"),
+	createVoiceButton: jest.fn(() => "VoiceButton"),
+	getButtonConfig: jest.fn(),
+}));
+jest.mock("../../../src/constants/Button", () => ({
+	Button: {
+		CLOSE_CHAT_BUTTON: "close",
+		AUDIO_BUTTON: "audio",
+		NOTIFICATION_BUTTON: "notification",
+		EMOJI_PICKER_BUTTON: "emoji",
+		FILE_ATTACHMENT_BUTTON: "file",
+		SEND_MESSAGE_BUTTON: "send",
+		VOICE_MESSAGE_BUTTON: "voice",
+	},
+}));
+
+describe("useButtonInternal", () => {
+	const mockSettings = { some: "settings" };
+	const mockHeader = ["CloseChatButton"];
+	const mockChatInput = ["SendButton", "EmojiButton"];
+	const mockFooter = ["AudioButton", "VoiceButton"];
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		require("../../../src/context/SettingsContext").useSettingsContext.mockReturnValue({ settings: mockSettings });
+		require("../../../src/utils/buttonBuilder").getButtonConfig.mockReturnValue({
+			header: mockHeader,
+			chatInput: mockChatInput,
+			footer: mockFooter,
+		});
+	});
+
+	it("should return headerButtons, chatInputButtons, and footerButtons from getButtonConfig", () => {
+		const { result } = renderHook(() => useButtonInternal());
+		expect(result.current.headerButtons).toEqual(mockHeader);
+		expect(result.current.chatInputButtons).toEqual(mockChatInput);
+		expect(result.current.footerButtons).toEqual(mockFooter);
+	});
+
+	it("should call getButtonConfig with settings and staticButtonComponentMap", () => {
+		renderHook(() => useButtonInternal());
+		expect(require("../../../src/utils/buttonBuilder").getButtonConfig).toHaveBeenCalledWith(
+			mockSettings,
+			expect.any(Object)
+		);
+	});
+
+	it("should update buttons when settings change", () => {
+		const { rerender, result } = renderHook(() => useButtonInternal());
+		expect(result.current.headerButtons).toEqual(mockHeader);
+
+		// Change settings and mock new return
+		const newSettings = { other: "settings" };
+		const newHeader = ["NotificationButton"];
+		require("../../../src/context/SettingsContext").useSettingsContext.mockReturnValue({ settings: newSettings });
+		require("../../../src/utils/buttonBuilder").getButtonConfig.mockReturnValue({
+			header: newHeader,
+			chatInput: [],
+			footer: [],
+		});
+
+		rerender();
+		expect(result.current.headerButtons).toEqual(newHeader);
+	});
+});


### PR DESCRIPTION
#### Description

Add unit tests for the `useButtonInternal `hook to improve test coverage and ensure correct button rendering based on settings.

Closes #345

#### What change does this PR introduce?

Please select the relevant option(s).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

This PR introduces Jest test cases for the `useButtonInternal` hook. The tests verify that the hook returns the correct button arrays (`headerButtons`, `chatInputButtons`, `footerButtons`), calls `getButtonConfig` with the right arguments, and updates the buttons when settings change.

#### Checklist:

- [x] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Testing has been done for the change(s) added (for bug fixes/features)
- [ ] Relevant comments/docs have been added/updated (for bug fixes/features)