### PR TITLE
fix: Fix circular dependency in ChatBotTooltip's useEffect causing an immediate re-render

### DIFF
--- a/__tests__/components/ChatBotTooltip/ChatBotTooltip.test.tsx
+++ b/__tests__/components/ChatBotTooltip/ChatBotTooltip.test.tsx
@@ -76,16 +76,34 @@ describe("ChatBotTooltip Component", () => {
 	// Test: Show the tooltip when mode is "START" (when component is rendered for the first time)
 	it('shows tooltip when mode is "START" and shownTooltipOnStart is false', () => {
 		// Mock the context to return settings with mode "START"
-		(useSettingsContext as jest.Mock).mockReturnValueOnce({
+		(useSettingsContext as jest.Mock).mockReturnValue({
 			settings: {
 				tooltip: { mode: "START", text: "Chatbot Tooltip" },
 			},
 		});
 
 		// Render the component and ensure the tooltip is shown
-		render(<ChatBotTooltip />);
-		const tooltip = screen.getByText("Chatbot Tooltip");
-		expect(tooltip).toBeInTheDocument(); 
+		const { rerender } = render(<ChatBotTooltip />);
+		const tooltip = screen.getByTestId("chat-tooltip");
+		expect(tooltip).toBeInTheDocument();
+		expect(tooltip).toHaveClass("rcb-tooltip-show");
+
+		// Simulate the user opening the chat window, which should hide the tooltip
+		(useChatWindowInternal as jest.Mock).mockReturnValue({
+			isChatWindowOpen: true,
+			toggleChatWindow: jest.fn(),
+		});
+		rerender(<ChatBotTooltip />);
+		expect(tooltip).toBeInTheDocument();
+		expect(tooltip).toHaveClass("rcb-tooltip-hide");
+
+		// Simulate the user closing the chat window, the tooltip should remain hidden.
+		(useChatWindowInternal as jest.Mock).mockReturnValue({
+			isChatWindowOpen: false,
+			toggleChatWindow: jest.fn(),
+		});
+		rerender(<ChatBotTooltip />);
+		expect(tooltip).toHaveClass("rcb-tooltip-hide");
 	});
 
 	// Test: Ensure the tooltip shows when mode is "CLOSE"

--- a/src/components/ChatBotTooltip/ChatBotTooltip.tsx
+++ b/src/components/ChatBotTooltip/ChatBotTooltip.tsx
@@ -75,7 +75,6 @@ const ChatBotTooltip = () => {
 	}, [
 		isChatWindowOpen,
 		isDesktop,
-		shownTooltipOnStart,
 		styles.chatButtonStyle?.width,
 		settings.tooltip?.mode,
 	]);


### PR DESCRIPTION
#### Description

Fixes a circular dependency in ChatBotTooltip's useEffect causing an immediate re-render, breaking the functionality of tooltip mode "START".

Closes #382

#### What change does this PR introduce?

Please select the relevant option(s).

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to docs/code comments)

#### What is the proposed approach?

1. The `useEffect` in `ChatBotTooltip.tsx` has a dependency of `shownTooltipOnStart`.
2. When `mode === "START"`, on first render, it calls `setShownTooltipOnStart(true);`
3. This triggers the dependency array, causing the `useEffect()` to be called again.
4. The second time `setShowTooltip(false);` gets called. Meaning that the tooltip is never shown when `mode === "START"`
5. _The unit test for this case also wasn't properly making sure that the tooltip was actually showing_

#### Checklist:

- [X] The commit message follows our adopted [guidelines](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Testing has been done for the change(s) added (for bug fixes/features)
- [X] Relevant comments/docs have been added/updated (for bug fixes/features)